### PR TITLE
add self-auditing tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ and was generated on 2023-05-19. See
 [Updating the files](#updating-the-files) for steps for rebuilding
 it.
 
+See [self-audit](#self-audit) if you want to check your own project on pypi!
+
 [PyPI's BigQuery dataset]: https://warehouse.pypa.io/api-reference/bigquery-datasets.html
 
 ## Updating the files
@@ -56,3 +58,16 @@ AND upload_time > TIMESTAMP("2020-03-27 00:00:00")
     < outputs/all-dist-keys.jsonl \
     > outputs/key-audit.json
 ```
+
+## Self-audit
+
+The script selfaudit-pypi-key.py checks the signature of the 
+most recent pypi release.
+
+Run as:
+
+```bash
+python selfaudit-pypi-key.py myprojectname
+```
+
+try for example: gpg, trytond_account_invoice_history, snowline, 

--- a/selfaudit-pypi-key.py
+++ b/selfaudit-pypi-key.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""
+Self-audit the GPG signing key of a PyPI project.
+
+Synapsis: selfaudit-pypi-key.py projectname
+
+Copyright (c) 2023 Johannes Buchner
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+import sys
+import requests
+import subprocess
+
+session = requests.Session()
+
+def download_file(url, filename):
+    r = requests.get(url)
+    with open(filename, 'wb') as fd:
+        fd.write(r.content)
+
+
+projectname = sys.argv[1]
+
+r = session.get('https://pypi.org/pypi/{}/json'.format(projectname))
+assert r.status_code == 200, ('pypi returned status %d for %s' % (r.status_code, projectname))
+projectinfo = r.json()
+
+for ver, releases in projectinfo['releases'].items():
+    print(ver, 'signed' if any([release['has_sig'] for release in releases]) else 'unsigned')
+
+assert any([release['has_sig'] for release in releases]), ('latest release "{}" not signed!'.format(ver))
+
+any_failures = False
+tmpkeyring = './{}-keyring.gpg'.format(projectname)
+
+for release in releases:
+    assert release['has_sig'], ('in latest version "{}", file {} is not signed!'.format(ver, release['filename']))
+
+    keyfile = release['url'] + '.asc'
+    print("fetching signature file", release['filename'] + '.asc', "...")
+    download_file(keyfile, release['filename'] + '.asc')
+    print("fetching release file", release['filename'], "...")
+    download_file(release['url'], release['filename'])
+    ok_here = False
+    for keyserver in 'keys.openpgp.org', 'keyserver.ubuntu.com', 'certserver.pgp.com':
+        args = ['gpg', '--verify', '--keyserver', keyserver, '--no-default-keyring', '--keyring', tmpkeyring,  '--auto-key-import', '--auto-key-retrieve', release['filename'] + '.asc']
+        print('running:', ' '.join(args))
+        try:
+            result = subprocess.check_output(args, text=True)
+            print(result)
+            for line in result.split('\n'):
+                if 'Good signature from' in line and '[expired]' not in line and '[revoke' not in line:
+                    ok_here = True
+                    print("ok")
+            break
+        except subprocess.CalledProcessError:
+            print("not successful!")
+    if not ok_here:
+        any_failures = True
+        break
+
+# import os
+# if os.path.exists(tmpkeyring):
+#     os.unlink(tmpkeyring)
+
+sys.exit(-1 if any_failures else 0)


### PR DESCRIPTION
This adds a small script so people can quickly check the status of their own projects.

At the moment this addresses the reachability of the key, and whether they are expired. Advanced things like key size or immanent expiry are not handled.